### PR TITLE
[OPS-154 / #51] fix: 보유 식재료 조회 시 CustomIngredient도 조회하기

### DIFF
--- a/src/main/java/dazaram/eureka/ingredient/dto/UserIngredientDetailsDto.java
+++ b/src/main/java/dazaram/eureka/ingredient/dto/UserIngredientDetailsDto.java
@@ -4,8 +4,10 @@ import java.time.LocalDate;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 
+import dazaram.eureka.ingredient.domain.CustomIngredient;
 import dazaram.eureka.ingredient.domain.UserIngredient;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -24,12 +26,36 @@ public class UserIngredientDetailsDto {
 	private String memo;
 	private BasicIngredientDto ingredient;
 
-	public UserIngredientDetailsDto(UserIngredient userIngredient) {
-		id = userIngredient.getId();
-		name = userIngredient.getName();
-		insertDate = userIngredient.getInsertDate();
-		expireDate = userIngredient.getExpireDate();
-		memo = userIngredient.getMemo();
-		ingredient = BasicIngredientDto.fromEntity(userIngredient.getIngredient());
+	@Builder
+	public UserIngredientDetailsDto(Long id, String name, LocalDate insertDate, LocalDate expireDate, String memo,
+		BasicIngredientDto ingredient) {
+		this.id = id;
+		this.name = name;
+		this.insertDate = insertDate;
+		this.expireDate = expireDate;
+		this.memo = memo;
+		this.ingredient = ingredient;
+	}
+
+	public static UserIngredientDetailsDto fromUserIngredient(UserIngredient userIngredient) {
+		return UserIngredientDetailsDto.builder()
+			.id(userIngredient.getId())
+			.ingredient(BasicIngredientDto.fromEntity(userIngredient.getIngredient()))
+			.name(userIngredient.getName())
+			.memo(userIngredient.getMemo())
+			.insertDate(userIngredient.getInsertDate())
+			.expireDate(userIngredient.getExpireDate())
+			.build();
+	}
+
+	public static UserIngredientDetailsDto fromCustomIngredient(CustomIngredient customIngredient) {
+		return UserIngredientDetailsDto.builder()
+			.id(customIngredient.getId())
+			.name(customIngredient.getName())
+			.memo(customIngredient.getMemo())
+			.insertDate(customIngredient.getInsertDate())
+			.expireDate(customIngredient.getExpireDate())
+			.ingredient(BasicIngredientDto.builder().icon(customIngredient.getIcon()).build())
+			.build();
 	}
 }

--- a/src/main/java/dazaram/eureka/ingredient/repository/CustomIngredientRepository.java
+++ b/src/main/java/dazaram/eureka/ingredient/repository/CustomIngredientRepository.java
@@ -1,8 +1,12 @@
 package dazaram.eureka.ingredient.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import dazaram.eureka.ingredient.domain.CustomIngredient;
+import dazaram.eureka.user.domain.User;
 
 public interface CustomIngredientRepository extends JpaRepository<CustomIngredient, Long> {
+	List<CustomIngredient> findAllByUser(User user);
 }

--- a/src/main/java/dazaram/eureka/ingredient/service/IngredientService.java
+++ b/src/main/java/dazaram/eureka/ingredient/service/IngredientService.java
@@ -129,9 +129,14 @@ public class IngredientService {
 
 	public List<UserIngredientDetailsDto> getAllUserIngredientDetails(Long userId) {
 		User user = getCurrentUser(userId);
-		return userIngredientRepository.findAllByUser(user).stream()
-			.map(UserIngredientDetailsDto::new)
+		List<UserIngredientDetailsDto> userIngredients = userIngredientRepository.findAllByUser(user).stream()
+			.map(UserIngredientDetailsDto::fromUserIngredient)
 			.collect(Collectors.toList());
+		List<UserIngredientDetailsDto> customIngredients = customIngredientRepository.findAllByUser(user).stream()
+			.map(UserIngredientDetailsDto::fromCustomIngredient)
+			.collect(Collectors.toList());
+		userIngredients.addAll(customIngredients);
+		return userIngredients;
 	}
 
 	@Transactional


### PR DESCRIPTION
기존
- IngredientApiController에서 findAllUserIngredientsByUserId 시 UserIngredients에서만 조회함

수정 내용
- UserIngredient와 CustomIngredient 두 곳에서 UserId를 이용한 보유 식재료 조회
- UserIngredient와 CustomIngredient 각각을 UserIngredientDetailsDto로 변환하는 로직을 빌더 패턴과 정적 메소드를 활용하여 작성
- 두 조회 결과를 합쳐서 결과 반환