### PR TITLE
[OPS-153 / #50] 유통기한 기반 추천 API 성능 개선

### DIFF
--- a/src/main/java/dazaram/eureka/elastic/domain/RecipeDocument.java
+++ b/src/main/java/dazaram/eureka/elastic/domain/RecipeDocument.java
@@ -1,6 +1,7 @@
 package dazaram.eureka.elastic.domain;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.persistence.Id;
@@ -46,7 +47,14 @@ public class RecipeDocument {
 	}
 
 	public List<Long> getAllIngredientsIds() {
-		return ingredients.stream().map(IngredientDocument::getId)
+		return ingredients.stream()
+			.map(IngredientDocument::getId)
 			.collect(Collectors.toList());
+	}
+	
+	public Set<Long> getAllIngredientsIdsSet() {
+		return ingredients.stream()
+			.map(IngredientDocument::getId)
+			.collect(Collectors.toSet());
 	}
 }

--- a/src/main/java/dazaram/eureka/elastic/repository/RecipeElasticQueryRepository.java
+++ b/src/main/java/dazaram/eureka/elastic/repository/RecipeElasticQueryRepository.java
@@ -32,7 +32,7 @@ public class RecipeElasticQueryRepository {
 		Query query = new NativeSearchQueryBuilder()
 			.withQuery(new BoolQueryBuilder()
 				.must(QueryBuilders.matchQuery("ingredients.name", nameList).operator(Operator.OR)))
-			.withPageable(PageRequest.of(0, 1000))
+			.withPageable(PageRequest.of(0, 100))
 			.build();
 
 		SearchHits<RecipeDocument> search = elasticsearchOperations.search(query, RecipeDocument.class);

--- a/src/main/java/dazaram/eureka/elastic/service/RecipeElasticService.java
+++ b/src/main/java/dazaram/eureka/elastic/service/RecipeElasticService.java
@@ -123,15 +123,11 @@ public class RecipeElasticService {
 
 		if (!checkDuplicateIngredients.contains(ingredientsIdsSet)) {
 			checkDuplicateIngredients.add(ingredientsIdsSet);
-			System.out.print("저장한거");
-			System.out.println(recipeDocument.getTitle());
 			recipeDtos.add(ExpireDateRecipeDto.fromDocument(recipeDocument,
 				getImminentIngredient(userIngredients)));
 			// 다른 재료를 사용하는 레시피가 원하는 갯수만큼 없을 경우 사용하도록 저장해놓는다
 			// 최소 1개는 추천했을 때 이 구문이 실행되므로 topRank - 1
 		} else if (spareRecipeDtos.size() < topRank - 1) {
-			System.out.print("XXXXX");
-			System.out.println(recipeDocument.getTitle());
 			spareRecipeDtos.add(ExpireDateRecipeDto.fromDocument(recipeDocument,
 				getImminentIngredient(userIngredients)));
 		}
@@ -142,8 +138,6 @@ public class RecipeElasticService {
 		int i = 0;
 		while (recipeDtos.size() < topRank) {
 			recipeDtos.add(spareRecipeDtos.get(i));
-			System.out.println("spare");
-			System.out.println(spareRecipeDtos.get(i).getTitle());
 			i++;
 
 		}

--- a/src/main/java/dazaram/eureka/elastic/service/RecipeElasticService.java
+++ b/src/main/java/dazaram/eureka/elastic/service/RecipeElasticService.java
@@ -136,7 +136,7 @@ public class RecipeElasticService {
 	private void fillRecipeDtosWithSpare(int topRank, List<ExpireDateRecipeDto> recipeDtos,
 		List<ExpireDateRecipeDto> spareRecipeDtos) {
 		int i = 0;
-		while (recipeDtos.size() < topRank) {
+		while (recipeDtos.size() < topRank && i < spareRecipeDtos.size()) {
 			recipeDtos.add(spareRecipeDtos.get(i));
 			i++;
 

--- a/src/main/java/dazaram/eureka/elastic/service/RecipeElasticService.java
+++ b/src/main/java/dazaram/eureka/elastic/service/RecipeElasticService.java
@@ -98,17 +98,16 @@ public class RecipeElasticService {
 			if (Math.abs(indexAndScore.getValue()) < minScore) {
 				break;
 			}
-			Ingredient imminentIngredient = getImminentIngredient(queryResults.get(indexAndScore.getKey()),
-				userIngredients);
-			recipeDtos.add(
-				ExpireDateRecipeDto.fromDocument(queryResults.get(indexAndScore.getKey()), imminentIngredient));
+
+			recipeDtos.add(ExpireDateRecipeDto.fromDocument(queryResults.get(indexAndScore.getKey()),
+				getImminentIngredient(userIngredients)));
 		}
+
 		validateRecipeDtos(recipeDtos);
 		return recipeDtos;
 	}
 
-	private Ingredient getImminentIngredient(RecipeDocument recipeDocument, List<UserIngredient> userIngredients) {
-		List<Long> ingredientsIds = recipeDocument.getAllIngredientsIds();
+	private Ingredient getImminentIngredient(List<UserIngredient> userIngredients) {
 		Map.Entry<Ingredient, Long> ret = new AbstractMap.SimpleEntry<>(null, Long.MAX_VALUE);
 		for (UserIngredient userIngredient : userIngredients) {
 			long expire = userIngredient.calculateExpireFromNow();


### PR DESCRIPTION
## 구현 기능
유통기한 기반 추천 API의 속도, 정확성 개선
![image](https://user-images.githubusercontent.com/81469045/203255548-58c862d9-f351-43fe-85c8-b286dee1c538.png)

## 상세 작업 내용
- 속도 개선을 위해 불필요한 레시피는 호출되지 않도록 한다
   - ElasticSearch에서 최대 100개의 레시피 가져오도록 호출
   - 너무 많이 가져오면 통신 느리고 자주 호출 시 Heap터짐
- 정확도 개선을 위해 추천 레시피 중 중복된 재료를 사용하는 레시피는 제외한다
    - 중복된 재료를 가진 레시피는 추천 빈도를 낮춤
        - Set 활용
    - 추천해야하는 레시피 갯수 충족 못할시에 중복된 재료 가진 레시피도 포함해서 추천